### PR TITLE
Feature: Collection assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-07-29
+### Added
+- operations:
+  - `:to-conjoin`
+  - `:to-pop`
+- flags:
+  - `:with` for asserting on conjoined values
+  - `:times` for asserting on number of `pop`s
+- discounted conformance of input to an implicit schema
+
+### Fixed
+- treats symbol-headed lists as functions (#5)
+
+### Changed
+- flags may be shared across operations
+- improves validation of input
+
 ## [0.5.0] - 2024-01-24
 ### Added
 - Support for disjunction of generated assertions
@@ -75,7 +92,8 @@ Renamed:
 - Initial commit.
 - asserts only, i.e. runs effect and monitors in a function.
 
-[Unreleased]: https://github.com/eureton/effective/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/eureton/effective/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/eureton/effective/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/eureton/effective/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/eureton/effective/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/eureton/effective/compare/0.2.0...0.3.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-Use the `expect` macro to string up any number of assertions with respect to a given Clojure form. Assertions are grouped by expressions - use `:to-change` and `:to-not-change` to specify expressions.
+Use the `expect` macro to string up any number of assertions with respect to a given Clojure form. Assertions are grouped by expressions - use `:to-change`, `:to-not-change` and `:to-conjoin` to specify expressions.
 
 Multiple expressions may be specified. By default, `expect` generates code which asserts that they **all** hold. You may use the keyword `:any` (see example below) to specify that **one or more** of them hold.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The above expands to the following:
 
 ---
 
-`:from-within` / `:to-within` let us assert that a checkpoint lies within some continuous numerical range. Use a `[radius :of origin]` vector as follows:
+`:from-within` / `:to-within` let us assert that a checkpoint lies within some continuous numerical range. Use them with a `[radius :of origin]` vector as follows:
 
 ``` clojure
 (let [x (atom 0)]

--- a/README.md
+++ b/README.md
@@ -4,33 +4,7 @@
 
 ## Installation
 
-### Leiningen/Boot
-
-``` clj
-[com.eureton/effective "0.5.0"]
-```
-
-### Clojure CLI/deps.edn
-
-``` clj
-com.eureton/effective {:mvn/version "0.5.0"}
-```
-
-### Gradle
-
-``` java
-implementation("com.eureton:effective:0.5.0")
-```
-
-### Maven
-
-``` xml
-<dependency>
-  <groupId>com.eureton</groupId>
-  <artifactId>effective</artifactId>
-  <version>0.5.0</version>
-</dependency>
-```
+[![Clojars Project](https://img.shields.io/clojars/v/com.eureton/effective.svg)](https://clojars.org/com.eureton/effective)
 
 ## Usage
 
@@ -119,6 +93,50 @@ The above expands to the following:
   (is (odd? before-0) ":from check failed")
   (is (even? after-0) ":to check failed"))
 ```
+
+---
+
+`:from-within` / `:to-within` let us assert that a checkpoint lies within some continuous numerical range. Use a `[radius :of origin]` vector as follows:
+
+``` clojure
+(let [x (atom 0)]
+  (expect (swap! x inc)
+          [{:to-change @x :from-within [0.6 :of -0.05]}]))
+```
+
+The above expands to the following:
+
+``` clojure
+(let [x (atom 0)]
+  (let [before-0 @x
+        _ (swap! x inc)
+        after-0 @x]
+    (is (>= 0.6 (java.lang.Math/abs (- before-0 -0.05)))
+        \":from-within check failed\")))
+```
+
+---
+
+Assert growth of sequential collections by means of `:to-conjoin`. It may be given either static values or predicates:
+
+``` clojure
+(let [x (atom [-2 -1])]
+  (expect (reset! x [-2 -1 0 1 2])
+          [{:to-conjoin @x :with [zero? 1 even?]}]))
+```
+
+The above expands to the following:
+
+``` clojure
+(let [x (atom [-2 -1])]
+  (let [before-0 @x
+        _ (reset! x [-2 -1 0 1 2])
+        after-0 @x]
+    (is (= before-0 (pop (pop (pop after-0)))) \":with check failed\")
+    (is (zero? (peek (pop (pop after-0)))) \":with check failed\")
+    (is (= 1 (peek (pop after-0))) \":with check failed\")
+    (is (even? (peek after-0)) \":with check failed\")))
+```"
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-Use the `expect` macro to string up any number of assertions with respect to a given Clojure form. Assertions are grouped by expressions - use `:to-change`, `:to-not-change` and `:to-conjoin` to specify expressions.
+Use the `expect` macro to string up any number of assertions with respect to a given Clojure form. Assertions are grouped by expressions - use `:to-change`, `:to-not-change`, `:to-conjoin` and `:to-pop` to specify expressions.
 
 Multiple expressions may be specified. By default, `expect` generates code which asserts that they **all** hold. You may use the keyword `:any` (see example below) to specify that **one or more** of them hold.
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ The above expands to the following:
         _ (swap! x inc)
         after-0 @x]
     (is (>= 0.6 (java.lang.Math/abs (- before-0 -0.05)))
-        \":from-within check failed\")))
+        ":from-within check failed")))
 ```
 
 ---
 
-Assert growth of sequential collections by means of `:to-conjoin`. It may be given either static values or predicates:
+Assert growth of sequential collections with `:to-conjoin`. It may be given either static values or predicates:
 
 ``` clojure
 (let [x (atom [-2 -1])]
@@ -132,11 +132,11 @@ The above expands to the following:
   (let [before-0 @x
         _ (reset! x [-2 -1 0 1 2])
         after-0 @x]
-    (is (= before-0 (pop (pop (pop after-0)))) \":with check failed\")
-    (is (zero? (peek (pop (pop after-0)))) \":with check failed\")
-    (is (= 1 (peek (pop after-0))) \":with check failed\")
-    (is (even? (peek after-0)) \":with check failed\")))
-```"
+    (is (= before-0 (pop (pop (pop after-0)))) ":with check failed")
+    (is (zero? (peek (pop (pop after-0)))) ":with check failed")
+    (is (= 1 (peek (pop after-0))) ":with check failed")
+    (is (even? (peek after-0)) ":with check failed")))
+```
 
 ## Development
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.eureton/effective "0.5.0"
+(defproject com.eureton/effective "0.6.0"
   :description "RSpec-style expect-to-change assertions for Clojure."
   :url "https://github.com/eureton/effective"
   :license {:name "MIT"

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -42,7 +42,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change :with :with-hash-containing])
+   :to-not-change :with])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -1,6 +1,7 @@
 (ns effective.assertion
   "Generates data representations of assertions."
   (:require [clojure.set :as cljset]
+            [effective.config :as config]
             [effective.predicate :as predicate]))
 
 (defn- message
@@ -58,14 +59,15 @@
 (defn- inflate
   "Builds a function which turns a flag-value pair into a collection
    of data structures."
-  [index]
+  [index operation]
   (fn [[k v]]
     (map (fn [x]
            {:flag k
             :value v
+            :operation operation
             :predicate x
             :message (message k)})
-         (predicate/make k v index))))
+         (predicate/make operation k v index))))
 
 (defn make
   "Vector of the assertions which correspond to `config`.
@@ -74,4 +76,4 @@
   (->> config
        (normalize)
        (sanitize)
-       (mapcat (inflate index))))
+       (mapcat (inflate index (config/operation config)))))

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -42,7 +42,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change])
+   :to-not-change :with])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -56,13 +56,16 @@
   (select-keys config CONFIG_KEYS))
 
 (defn- inflate
-  "Builds a function which turns a flag-value pair into a data structure."
+  "Builds a function which turns a flag-value pair into a collection
+   of data structures."
   [index]
   (fn [[k v]]
-    {:flag k
-     :value v
-     :predicates (predicate/make k v index)
-     :message (message k)}))
+    (map (fn [x]
+           {:flag k
+            :value v
+            :predicate x
+            :message (message k)})
+         (predicate/make k v index))))
 
 (defn make
   "Vector of the assertions which correspond to `config`.
@@ -71,4 +74,4 @@
   (->> config
        (normalize)
        (sanitize)
-       (map (inflate index))))
+       (mapcat (inflate index))))

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -43,7 +43,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change :with :times])
+   :to-not-change :with :to-pop :times])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -43,7 +43,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change :with :to-pop])
+   :to-not-change :with :times])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."
@@ -55,6 +55,12 @@
   "Culls unknown keys in user input."
   [config]
   (select-keys config CONFIG_KEYS))
+
+(defn- initialize
+  "Applies default values, where necessary."
+  [config]
+  (cond->> config
+    (:to-pop config) (merge {:times 1})))
 
 (defn- inflate
   "Builds a function which turns a flag-value pair into a collection
@@ -76,4 +82,5 @@
   (->> config
        (normalize)
        (sanitize)
+       (initialize)
        (mapcat (inflate index (config/operation config)))))

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -43,7 +43,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change :with])
+   :to-not-change :with :to-pop])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -61,7 +61,7 @@
   (fn [[k v]]
     {:flag k
      :value v
-     :predicate (predicate/make k v index)
+     :predicates (predicate/make k v index)
      :message (message k)}))
 
 (defn make

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -42,7 +42,7 @@
    :by :by-lt :by-lte :by-gt :by-gte :by-not :by-within
    :by-less-than :by-less-than-or-equal
    :by-greater-than :by-greater-than-or-equal
-   :to-not-change :with])
+   :to-not-change :with :with-hash-containing])
 
 (defn- normalize
   "Transforms user input to a consistent, unambiguous format."

--- a/src/effective/assertion/composer.clj
+++ b/src/effective/assertion/composer.clj
@@ -11,11 +11,7 @@
 
   (intra [_]
     (fn [assertions]
-      (->> assertions
-           (mapcat (fn [x] (for [predicate (:predicates x)]
-                             {:predicate predicate
-                              :message (:message x)})))
-           (map (fn [x] `(is ~(:predicate x) ~(:message x)))))))
+      (map (fn [x] `(is ~(:predicate x) ~(:message x))) assertions)))
 
   (inter [_]
     (fn [assertions] (mapcat identity assertions))))
@@ -25,7 +21,9 @@
 
   (intra [_]
     (fn [assertions]
-      `(and ~@(mapcat :predicates assertions))))
+      (if (-> assertions (count) (> 1))
+        `(and ~@(map :predicate assertions))
+        (-> assertions first :predicate))))
 
   (inter [_]
     (fn [assertions] `[(is (or ~@assertions))])))

--- a/src/effective/assertion/composer.clj
+++ b/src/effective/assertion/composer.clj
@@ -11,7 +11,11 @@
 
   (intra [_]
     (fn [assertions]
-      (map (fn [x] `(is ~(:predicate x) ~(:message x))) assertions)))
+      (->> assertions
+           (mapcat (fn [x] (for [predicate (:predicates x)]
+                             {:predicate predicate
+                              :message (:message x)})))
+           (map (fn [x] `(is ~(:predicate x) ~(:message x)))))))
 
   (inter [_]
     (fn [assertions] (mapcat identity assertions))))
@@ -21,9 +25,7 @@
 
   (intra [_]
     (fn [assertions]
-      (if (-> assertions (count) (> 1))
-        `(and ~@(map :predicate assertions))
-        (-> assertions first :predicate))))
+      `(and ~@(mapcat :predicates assertions))))
 
   (inter [_]
     (fn [assertions] `[(is (or ~@assertions))])))

--- a/src/effective/checkpoint.clj
+++ b/src/effective/checkpoint.clj
@@ -1,13 +1,13 @@
 (ns effective.checkpoint
-  "Symbolic names for referencing the state of the monitored expressions.")
+  "Symbolic names for referencing the state of the observables.")
 
 (defn- prefixed-symbol [prefix index]
   (symbol (str prefix "-" index)))
 
 (def before
-  "Symbol generator for the before-state of the monitored expression."
+  "Symbol generator for the before-state of the observable."
   (partial prefixed-symbol "before"))
 
 (def after
-  "Symbol generator for the after-state of the monitored expression."
+  "Symbol generator for the after-state of the observable."
   (partial prefixed-symbol "after"))

--- a/src/effective/config.clj
+++ b/src/effective/config.clj
@@ -1,0 +1,6 @@
+(ns effective.config)
+
+(defn observables
+  "Sequence of declared observables."
+  [config]
+  (map (some-fn :to-change :to-not-change :to-conjoin) config))

--- a/src/effective/config.clj
+++ b/src/effective/config.clj
@@ -1,7 +1,7 @@
 (ns effective.config
   (:require [clojure.set :as cljset]))
 
-(def ^:const OPERATIONS #{:to-change :to-not-change :to-conjoin})
+(def ^:const OPERATIONS #{:to-change :to-not-change :to-conjoin :to-pop})
 
 (defn operation [entry]
   (->> entry (keys) (set) (cljset/intersection OPERATIONS) (first)))

--- a/src/effective/config.clj
+++ b/src/effective/config.clj
@@ -1,4 +1,10 @@
-(ns effective.config)
+(ns effective.config
+  (:require [clojure.set :as cljset]))
+
+(def ^:const OPERATIONS #{:to-change :to-not-change :to-conjoin})
+
+(defn operation [entry]
+  (->> entry (keys) (set) (cljset/intersection OPERATIONS) (first)))
 
 (defn observables
   "Sequence of declared observables."

--- a/src/effective/config.clj
+++ b/src/effective/config.clj
@@ -9,4 +9,4 @@
 (defn observables
   "Sequence of declared observables."
   [config]
-  (map (some-fn :to-change :to-not-change :to-conjoin) config))
+  (map (apply some-fn OPERATIONS) config))

--- a/src/effective/core.clj
+++ b/src/effective/core.clj
@@ -10,20 +10,43 @@
 
    `effect` is a Clojure form representing the effect to test.
 
-   `config` is expected to be a collection of monitor configurations. Each of
-   those to be a hashmap with the following keys:
+   `config` is a collection of declarations, each of which consists of:
+     * an **observable**
+     * one or more **assertions** on the observable
 
-   | key          | required? | description                    |
-   | ------------ | --------- | ------------------------------ |
-   | `:to-change` | **yes**   | expression to evaluate         |
-   | `:from`      | **no**    | expected value of `:to-change` |
-   |              |           | before the effect              |
-   | `:to`        | **no**    | expected value of `:to-change` |
-   |              |           | after the effect               |
-   | `:by`        | **no**    | expected numerical difference  |
-   |              |           | of `:to-change` before and     |
-   |              |           | after the effect               |
-  
+   The observable is an expression and is declared by one of the following keys:
+
+   | key            | use when the value of the observable is expected |
+   | -------------- | ------------------------------------------------ |
+   | :to-change     | to change with the effect                        |
+   | :to-not-change | to remain unchanged by the effect                |
+   | :to-conjoin    | to be a collection which the effect conjoins to  |
+
+   Assertions are bound to **checkpoints**. Each observable has two checkpoints:
+     * **before** the effect (**b-val**)
+     * **after** the effect (**a-val**)
+
+   Assertions are declared by the following keys:
+
+   | key          | description                                               |
+   | ------------ | --------------------------------------------------------- |
+   | :from        | b-val or predicate to assert on b-val                     |
+   | :from-lt     | non-inclusive upper bound of b-val                        |
+   | :from-lte    | inclusive upper bound of b-val                            |
+   | :from-gt     | non-inclusive lower bound of b-val                        |
+   | :from-gte    | inclusive lower bound of b-val                            |
+   | :from-not    | value which b-val is expected to not be equal to          |
+   | :from-within | radius declaration vector (see example below) on b-val    |
+   | :to          | a-val or predicate to assert on a-val                     |
+   | :to-lt       | non-inclusive upper bound of a-val                        |
+   | :to-lte      | inclusive upper bound of a-val                            |
+   | :to-gt       | non-inclusive lower bound of a-val                        |
+   | :to-gte      | inclusive lower bound of a-val                            |
+   | :to-not      | value which a-val is expected to not be equal to          |
+   | :to-within   | radius declaration vector (see example below) on a-val    |
+   | :by          | numerical difference between b-val and a-val or predicate |
+   |              |  to assert on that difference.                            |
+
    **Examples**:
    ``` clojure
    (let [x (atom 10)]
@@ -84,6 +107,24 @@
        (is (or (and (= 3 before-0)
                     (= 4 after-0))
                (= after-1 before-1)))))
+   ```
+
+   ---
+
+   ``` clojure
+   (let [x (atom 0)]
+     (expect (swap! x inc)
+             [{:to-change @x :from-within [0.6 :of -0.05]}]))
+   ```
+
+   The above expands to the following:
+
+   ``` clojure
+   (let [before-0 @x
+         _ (swap! x inc)
+         after-0 @x]
+     (is (>= 0.6 (java.lang.Math/abs (- before-0 -0.05)))
+         \":from-within check failed\"))
    ```"
   ([effect config]
    `(expect ~effect :all ~config))

--- a/src/effective/core.clj
+++ b/src/effective/core.clj
@@ -2,6 +2,7 @@
   (:require [effective.assertion :as assertion]
             [effective.assertion.composer :as composer]
             [effective.checkpoint :as checkpoint]
+            [effective.config :as config]
             [effective.validation :as validation]))
 
 (defmacro expect
@@ -88,7 +89,7 @@
    `(expect ~effect :all ~config))
   ([effect composition config]
    (if (validation/config-valid? config)
-     (let [observables-seq (map #(or (:to-change %) (:to-not-change %)) config)
+     (let [observables-seq (config/observables config)
            before (interleave (map checkpoint/before (range)) observables-seq)
            after (interleave (map checkpoint/after (range)) observables-seq)
            composer (composer/make composition)

--- a/src/effective/core.clj
+++ b/src/effective/core.clj
@@ -120,11 +120,33 @@
    The above expands to the following:
 
    ``` clojure
-   (let [before-0 @x
-         _ (swap! x inc)
-         after-0 @x]
-     (is (>= 0.6 (java.lang.Math/abs (- before-0 -0.05)))
-         \":from-within check failed\"))
+   (let [x (atom 0)]
+     (let [before-0 @x
+           _ (swap! x inc)
+           after-0 @x]
+       (is (>= 0.6 (java.lang.Math/abs (- before-0 -0.05)))
+           \":from-within check failed\")))
+   ```
+
+   ---
+
+   ``` clojure
+   (let [x (atom [-2 -1])]
+     (expect (reset! x [-2 -1 0 1 2])
+             [{:to-conjoin @x :with [zero? 1 even?]}]))
+   ```
+
+   The above expands to the following:
+
+   ``` clojure
+   (let [x (atom [-2 -1])]
+     (let [before-0 @x
+           _ (reset! x [-2 -1 0 1 2])
+           after-0 @x]
+       (is (= before-0 (pop (pop (pop after-0)))) \":with check failed\")
+       (is (zero? (peek (pop (pop after-0)))) \":with check failed\")
+       (is (= 1 (peek (pop after-0))) \":with check failed\")
+       (is (even? (peek after-0)) \":with check failed\")))
    ```"
   ([effect config]
    `(expect ~effect :all ~config))

--- a/src/effective/core.clj
+++ b/src/effective/core.clj
@@ -21,6 +21,7 @@
    | :to-change     | to change with the effect                        |
    | :to-not-change | to remain unchanged by the effect                |
    | :to-conjoin    | to be a collection which the effect conjoins to  |
+   | :to-pop        | to be a collection which the effect pops         |
 
    Assertions are bound to **checkpoints**. Each observable has two checkpoints:
      * **before** the effect (**b-val**)
@@ -46,6 +47,7 @@
    | :to-within   | radius declaration vector (see example below) on a-val    |
    | :by          | numerical difference between b-val and a-val or predicate |
    |              |  to assert on that difference.                            |
+   | :times       | number of times to pop b-val collection                   |
 
    **Examples**:
    ``` clojure

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -12,6 +12,10 @@
            (every-pred list?
                        (comp symbol? first))))
 
+(defmethod make :default
+  [_ _ _ _]
+  [])
+
 (defmethod make [:to-change :from]
   [_ _ from index]
   (let [before (checkpoint/before index)]

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -144,3 +144,7 @@
                           (if (function? x)
                             `(~x ~head)
                             `(= ~x ~head))))))))))
+
+(defmethod make [:to-pop :to-pop]
+  [_ _ _ index]
+  [`(= ~(checkpoint/after index) (pop ~(checkpoint/before index)))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -121,8 +121,8 @@
 
 (defmethod make :with-hash-containing
   [_ value index]
-  [`(= ~(checkpoint/before index) (butlast ~(checkpoint/after index)))
+  [`(= ~(checkpoint/before index) (pop ~(checkpoint/after index)))
    `(= ~value (->> ~value
                    (keys)
                    (vec)
-                   (select-keys (last ~(checkpoint/after index)))))])
+                   (select-keys (peek ~(checkpoint/after index)))))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -124,4 +124,4 @@
   [`(= ~(checkpoint/before index) (pop ~(checkpoint/after index)))
    `(= ~value (-> ~(checkpoint/after index)
                   (peek)
-                  (select-keys (vec (keys ~value)))))])
+                  (select-keys (keys ~value))))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -2,7 +2,7 @@
   (:require [effective.checkpoint :as checkpoint]))
 
 (defmulti make
-  "Quoted expression representing the check specified by `flag`."
+  "Quoted expressions representing the check specified by `flag`."
   (fn [flag _ _] flag))
 
 (def ^:private function?
@@ -13,107 +13,108 @@
 (defmethod make :from
   [_ from index]
   (let [before (checkpoint/before index)]
-    (if (function? from)
-      `(~from ~before)
-      `(= ~from ~before))))
+    [(if (function? from)
+       `(~from ~before)
+       `(= ~from ~before))]))
 
 (defmethod make :from-lt
   [_ from-lt index]
-  `(> ~from-lt ~(checkpoint/before index)))
+  [`(> ~from-lt ~(checkpoint/before index))])
 
 (defmethod make :from-lte
   [_ from-lte index]
-  `(>= ~from-lte ~(checkpoint/before index)))
+  [`(>= ~from-lte ~(checkpoint/before index))])
 
 (defmethod make :from-gt
   [_ from-gt index]
-  `(< ~from-gt ~(checkpoint/before index)))
+  [`(< ~from-gt ~(checkpoint/before index))])
 
 (defmethod make :from-gte
   [_ from-gte index]
-  `(<= ~from-gte ~(checkpoint/before index)))
+  [`(<= ~from-gte ~(checkpoint/before index))])
 
 (defmethod make :from-not
   [_ from-not index]
-  `(not= ~from-not ~(checkpoint/before index)))
+  [`(not= ~from-not ~(checkpoint/before index))])
 
 (defmethod make :from-within
   [_ from-within index]
   (let [[from-radius _ from-origin] from-within]
-    `(>= ~from-radius (Math/abs (- ~(checkpoint/before index) ~from-origin)))))
+    [`(>= ~from-radius
+          (Math/abs (- ~(checkpoint/before index) ~from-origin)))]))
 
 (defmethod make :to
   [_ to index]
   (let [after (checkpoint/after index)]
-    (if (function? to)
-      `(~to ~after)
-      `(= ~to ~after))))
+    [(if (function? to)
+       `(~to ~after)
+       `(= ~to ~after))]))
 
 (defmethod make :to-lt
   [_ to-lt index]
-  `(> ~to-lt ~(checkpoint/after index)))
+  [`(> ~to-lt ~(checkpoint/after index))])
 
 (defmethod make :to-lte
   [_ to-lte index]
-  `(>= ~to-lte ~(checkpoint/after index)))
+  [`(>= ~to-lte ~(checkpoint/after index))])
 
 (defmethod make :to-gt
   [_ to-gt index]
-  `(< ~to-gt ~(checkpoint/after index)))
+  [`(< ~to-gt ~(checkpoint/after index))])
 
 (defmethod make :to-gte
   [_ to-gte index]
-  `(<= ~to-gte ~(checkpoint/after index)))
+  [`(<= ~to-gte ~(checkpoint/after index))])
 
 (defmethod make :to-not
   [_ to-not index]
-  `(not= ~to-not ~(checkpoint/after index)))
+  [`(not= ~to-not ~(checkpoint/after index))])
 
 (defmethod make :to-within
   [_ to-within index]
   (let [[to-radius _ to-origin] to-within]
-    `(>= ~to-radius (Math/abs (- ~(checkpoint/after index) ~to-origin)))))
+    [`(>= ~to-radius (Math/abs (- ~(checkpoint/after index) ~to-origin)))]))
 
 (defmethod make :by
   [_ by index]
   (let [before (checkpoint/before index)
         after (checkpoint/after index)]
-    (if (function? by)
-      `(~by (- ~after ~before))
-      `(= ~by (- ~after ~before)))))
+    [(if (function? by)
+       `(~by (- ~after ~before))
+       `(= ~by (- ~after ~before)))]))
 
 (defmethod make :by-lt
   [_ by-lt index]
-  `(> ~by-lt (- ~(checkpoint/after index) ~(checkpoint/before index))))
+  [`(> ~by-lt (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
 (defmethod make :by-lte
   [_ by-lte index]
-  `(>= ~by-lte (- ~(checkpoint/after index) ~(checkpoint/before index))))
+  [`(>= ~by-lte (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
 (defmethod make :by-gt
   [_ by-gt index]
-  `(< ~by-gt (- ~(checkpoint/after index) ~(checkpoint/before index))))
+  [`(< ~by-gt (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
 (defmethod make :by-gte
   [_ by-gte index]
-  `(<= ~by-gte (- ~(checkpoint/after index) ~(checkpoint/before index))))
+  [`(<= ~by-gte (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
 (defmethod make :by-not
   [_ by-not index]
-  `(not= ~by-not (- ~(checkpoint/after index) ~(checkpoint/before index))))
+  [`(not= ~by-not (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
 (defmethod make :by-within
   [_ by-within index]
   (let [[by-radius _ by-origin] by-within]
-    `(>= ~by-radius
-         (-> (- ~(checkpoint/after index) ~(checkpoint/before index))
-             (- ~by-origin)
-             (Math/abs)))))
+    [`(>= ~by-radius
+          (-> (- ~(checkpoint/after index) ~(checkpoint/before index))
+              (- ~by-origin)
+              (Math/abs)))]))
 
 (defmethod make :to-not-change
   [_ _ index]
-  `(= ~(checkpoint/after index) ~(checkpoint/before index)))
+  [`(= ~(checkpoint/after index) ~(checkpoint/before index))])
 
 (defmethod make :with
   [_ with index]
-  `(= ~(checkpoint/after index) (conj ~(checkpoint/before index) ~with)))
+  [`(= ~(checkpoint/after index) (conj ~(checkpoint/before index) ~with))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -132,15 +132,15 @@
   (let [before (checkpoint/before index)
         after (checkpoint/after index)
         tally (count with)
-        pick (fn [x]
-               `(peek ~(pop-times after (- tally x 1))))]
+        pick (fn [i]
+               `(peek ~(pop-times after (- tally i 1))))]
     (if (not-any? function? with)
       [`(= ~after (conj ~before ~@with))]
       (cons `(= ~before ~(pop-times after tally))
             (->> with
                  (map-indexed vector)
                  (map (fn [[i x]]
-                        (let [p (pick i)]
+                        (let [head (pick i)]
                           (if (function? x)
-                            `(~x ~p)
-                            `(= ~x ~p))))))))))
+                            `(~x ~head)
+                            `(= ~x ~head))))))))))

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -3,7 +3,7 @@
 
 (defmulti make
   "Quoted expressions representing the check specified by `flag`."
-  (fn [flag _ _] flag))
+  (fn [operation flag _ _] [operation flag]))
 
 (def ^:private function?
   "True if input represents a function, false otherwise."
@@ -12,113 +12,113 @@
            (every-pred list?
                        (comp symbol? first))))
 
-(defmethod make :from
-  [_ from index]
+(defmethod make [:to-change :from]
+  [_ _ from index]
   (let [before (checkpoint/before index)]
     [(if (function? from)
        `(~from ~before)
        `(= ~from ~before))]))
 
-(defmethod make :from-lt
-  [_ from-lt index]
+(defmethod make [:to-change :from-lt]
+  [_ _ from-lt index]
   [`(> ~from-lt ~(checkpoint/before index))])
 
-(defmethod make :from-lte
-  [_ from-lte index]
+(defmethod make [:to-change :from-lte]
+  [_ _ from-lte index]
   [`(>= ~from-lte ~(checkpoint/before index))])
 
-(defmethod make :from-gt
-  [_ from-gt index]
+(defmethod make [:to-change :from-gt]
+  [_ _ from-gt index]
   [`(< ~from-gt ~(checkpoint/before index))])
 
-(defmethod make :from-gte
-  [_ from-gte index]
+(defmethod make [:to-change :from-gte]
+  [_ _ from-gte index]
   [`(<= ~from-gte ~(checkpoint/before index))])
 
-(defmethod make :from-not
-  [_ from-not index]
+(defmethod make [:to-change :from-not]
+  [_ _ from-not index]
   [`(not= ~from-not ~(checkpoint/before index))])
 
-(defmethod make :from-within
-  [_ from-within index]
+(defmethod make [:to-change :from-within]
+  [_ _ from-within index]
   (let [[from-radius _ from-origin] from-within]
     [`(>= ~from-radius
           (Math/abs (- ~(checkpoint/before index) ~from-origin)))]))
 
-(defmethod make :to
-  [_ to index]
+(defmethod make [:to-change :to]
+  [_ _ to index]
   (let [after (checkpoint/after index)]
     [(if (function? to)
        `(~to ~after)
        `(= ~to ~after))]))
 
-(defmethod make :to-lt
-  [_ to-lt index]
+(defmethod make [:to-change :to-lt]
+  [_ _ to-lt index]
   [`(> ~to-lt ~(checkpoint/after index))])
 
-(defmethod make :to-lte
-  [_ to-lte index]
+(defmethod make [:to-change :to-lte]
+  [_ _ to-lte index]
   [`(>= ~to-lte ~(checkpoint/after index))])
 
-(defmethod make :to-gt
-  [_ to-gt index]
+(defmethod make [:to-change :to-gt]
+  [_ _ to-gt index]
   [`(< ~to-gt ~(checkpoint/after index))])
 
-(defmethod make :to-gte
-  [_ to-gte index]
+(defmethod make [:to-change :to-gte]
+  [_ _ to-gte index]
   [`(<= ~to-gte ~(checkpoint/after index))])
 
-(defmethod make :to-not
-  [_ to-not index]
+(defmethod make [:to-change :to-not]
+  [_ _ to-not index]
   [`(not= ~to-not ~(checkpoint/after index))])
 
-(defmethod make :to-within
-  [_ to-within index]
+(defmethod make [:to-change :to-within]
+  [_ _ to-within index]
   (let [[to-radius _ to-origin] to-within]
     [`(>= ~to-radius (Math/abs (- ~(checkpoint/after index) ~to-origin)))]))
 
-(defmethod make :by
-  [_ by index]
+(defmethod make [:to-change :by]
+  [_ _ by index]
   (let [before (checkpoint/before index)
         after (checkpoint/after index)]
     [(if (function? by)
        `(~by (- ~after ~before))
        `(= ~by (- ~after ~before)))]))
 
-(defmethod make :by-lt
-  [_ by-lt index]
+(defmethod make [:to-change :by-lt]
+  [_ _ by-lt index]
   [`(> ~by-lt (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
-(defmethod make :by-lte
-  [_ by-lte index]
+(defmethod make [:to-change :by-lte]
+  [_ _ by-lte index]
   [`(>= ~by-lte (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
-(defmethod make :by-gt
-  [_ by-gt index]
+(defmethod make [:to-change :by-gt]
+  [_ _ by-gt index]
   [`(< ~by-gt (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
-(defmethod make :by-gte
-  [_ by-gte index]
+(defmethod make [:to-change :by-gte]
+  [_ _ by-gte index]
   [`(<= ~by-gte (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
-(defmethod make :by-not
-  [_ by-not index]
+(defmethod make [:to-change :by-not]
+  [_ _ by-not index]
   [`(not= ~by-not (- ~(checkpoint/after index) ~(checkpoint/before index)))])
 
-(defmethod make :by-within
-  [_ by-within index]
+(defmethod make [:to-change :by-within]
+  [_ _ by-within index]
   (let [[by-radius _ by-origin] by-within]
     [`(>= ~by-radius
           (-> (- ~(checkpoint/after index) ~(checkpoint/before index))
               (- ~by-origin)
               (Math/abs)))]))
 
-(defmethod make :to-not-change
-  [_ _ index]
+(defmethod make [:to-not-change :to-not-change]
+  [_ _ _ index]
   [`(= ~(checkpoint/after index) ~(checkpoint/before index))])
 
-(defmethod make :with
-  [_ with index]
+(defmethod make [:to-conjoin :with]
+  [_ _ with index]
   (let [before (checkpoint/before index)
         after (checkpoint/after index)]
     (if (function? with)

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -118,3 +118,11 @@
 (defmethod make :with
   [_ with index]
   [`(= ~(checkpoint/after index) (conj ~(checkpoint/before index) ~with))])
+
+(defmethod make :with-hash-containing
+  [_ value index]
+  [`(= ~(checkpoint/before index) (butlast ~(checkpoint/after index)))
+   `(= ~value (->> ~value
+                   (keys)
+                   (vec)
+                   (select-keys (last ~(checkpoint/after index)))))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -113,3 +113,7 @@
 (defmethod make :to-not-change
   [_ _ index]
   `(= ~(checkpoint/after index) ~(checkpoint/before index)))
+
+(defmethod make :with
+  [_ with index]
+  `(= ~(checkpoint/after index) (conj ~(checkpoint/before index) ~with)))

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -119,11 +119,9 @@
 
 (defmethod make :with
   [_ with index]
-  [`(= ~(checkpoint/after index) (conj ~(checkpoint/before index) ~with))])
-
-(defmethod make :with-hash-containing
-  [_ value index]
-  [`(= ~(checkpoint/before index) (pop ~(checkpoint/after index)))
-   `(= ~value (-> ~(checkpoint/after index)
-                  (peek)
-                  (select-keys (keys ~value))))])
+  (let [before (checkpoint/before index)
+        after (checkpoint/after index)]
+    (if (function? with)
+      [`(= ~before (pop ~after))
+       `(~with (peek ~after))]
+      [`(= ~after (conj ~before ~with))])))

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -122,7 +122,6 @@
 (defmethod make :with-hash-containing
   [_ value index]
   [`(= ~(checkpoint/before index) (pop ~(checkpoint/after index)))
-   `(= ~value (->> ~value
-                   (keys)
-                   (vec)
-                   (select-keys (peek ~(checkpoint/after index)))))])
+   `(= ~value (-> ~(checkpoint/after index)
+                  (peek)
+                  (select-keys (vec (keys ~value)))))])

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -6,9 +6,11 @@
   (fn [flag _ _] flag))
 
 (def ^:private function?
-  "True if value is a symbol which represents a function, false otherwise."
-  (every-pred symbol?
-              (comp fn? var-get resolve)))
+  "True if input represents a function, false otherwise."
+  (some-fn (every-pred symbol?
+                       (comp fn? var-get resolve))
+           (every-pred list?
+                       (comp symbol? first))))
 
 (defmethod make :from
   [_ from index]

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -145,6 +145,7 @@
                             `(~x ~head)
                             `(= ~x ~head))))))))))
 
-(defmethod make [:to-pop :to-pop]
-  [_ _ _ index]
-  [`(= ~(checkpoint/after index) (pop ~(checkpoint/before index)))])
+(defmethod make [:to-pop :times]
+  [_ _ times index]
+  [`(= ~(checkpoint/after index)
+       ~(pop-times (checkpoint/before index) times))])

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -23,9 +23,7 @@
 (def ^:private to-conjoin-valid?
   (every-pred map?
               :to-conjoin
-              (some-fn :with :with-hash-containing)
-              (some-fn (missing? :with-hash-containing)
-                       (comp map? :with-hash-containing))))
+              :with))
 
 (def ^:private assertion-config-valid?
   (every-pred map?

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -1,5 +1,6 @@
 (ns effective.validation
-  (:require [clojure.set :as cljset]))
+  (:require [clojure.set :as cljset]
+            [effective.config :as config]))
 
 (def ^:private within-valid?
   (every-pred vector?
@@ -11,7 +12,7 @@
   (->> assertion
        (keys)
        (set)
-       (cljset/intersection #{:to-change :to-not-change :to-conjoin})
+       (cljset/intersection config/OPERATIONS)
        (count)
        (= 1)))
 

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -20,16 +20,21 @@
        (count)
        (= 1)))
 
+(defn- missing?
+  "Predicate which returns `true` if the input contains `x`, `false` otherwise."
+  [x]
+  #(not (contains? % x)))
+
 (def ^:private assertion-config-valid?
   (every-pred map?
               single-observable?
-              (some-fn #(not (contains? % :to-conjoin))
+              (some-fn (missing? :to-conjoin)
                        to-conjoin-valid?)
-              (some-fn #(not (contains? % :from-within))
+              (some-fn (missing? :from-within)
                        (comp within-valid? :from-within))
-              (some-fn #(not (contains? % :to-within))
+              (some-fn (missing? :to-within)
                        (comp within-valid? :to-within))
-              (some-fn #(not (contains? % :by-within))
+              (some-fn (missing? :by-within)
                        (comp within-valid? :by-within))))
 
 (def config-valid?

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -7,11 +7,6 @@
               (comp #{:of} #(nth % 1))
               (comp number? #(nth % 2))))
 
-(def ^:private to-conjoin-valid?
-  (every-pred map?
-              :to-conjoin
-              :with))
-
 (defn- single-observable? [assertion]
   (->> assertion
        (keys)
@@ -24,6 +19,13 @@
   "Predicate which returns `true` if the input contains `x`, `false` otherwise."
   [x]
   #(not (contains? % x)))
+
+(def ^:private to-conjoin-valid?
+  (every-pred map?
+              :to-conjoin
+              (some-fn :with :with-hash-containing)
+              (some-fn (missing? :with-hash-containing)
+                       (comp map? :with-hash-containing))))
 
 (def ^:private assertion-config-valid?
   (every-pred map?

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -1,4 +1,5 @@
-(ns effective.validation)
+(ns effective.validation
+  (:require [clojure.set :as cljset]))
 
 (def ^:private within-valid?
   (every-pred vector?
@@ -6,18 +7,23 @@
               (comp #{:of} #(nth % 1))
               (comp number? #(nth % 2))))
 
+(defn- single-observable? [assertion]
+  (->> assertion
+       (keys)
+       (set)
+       (cljset/intersection #{:to-change :to-not-change :to-conjoin})
+       (count)
+       (= 1)))
+
 (def ^:private assertion-config-valid?
-  (let [change? (comp some? :to-change)
-        no-change? (comp some? :to-not-change)]
-    (every-pred map?
-                (some-fn (every-pred change? (complement no-change?))
-                         (every-pred (complement change?) no-change?))
-                (some-fn #(not (contains? % :from-within))
-                         (comp within-valid? :from-within))
-                (some-fn #(not (contains? % :to-within))
-                         (comp within-valid? :to-within))
-                (some-fn #(not (contains? % :by-within))
-                         (comp within-valid? :by-within)))))
+  (every-pred map?
+              single-observable?
+              (some-fn #(not (contains? % :from-within))
+                       (comp within-valid? :from-within))
+              (some-fn #(not (contains? % :to-within))
+                       (comp within-valid? :to-within))
+              (some-fn #(not (contains? % :by-within))
+                       (comp within-valid? :by-within))))
 
 (def config-valid?
   (every-pred coll?

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -7,6 +7,11 @@
               (comp #{:of} #(nth % 1))
               (comp number? #(nth % 2))))
 
+(def ^:private to-conjoin-valid?
+  (every-pred map?
+              :to-conjoin
+              :with))
+
 (defn- single-observable? [assertion]
   (->> assertion
        (keys)
@@ -18,6 +23,8 @@
 (def ^:private assertion-config-valid?
   (every-pred map?
               single-observable?
+              (some-fn #(not (contains? % :to-conjoin))
+                       to-conjoin-valid?)
               (some-fn #(not (contains? % :from-within))
                        (comp within-valid? :from-within))
               (some-fn #(not (contains? % :to-within))

--- a/src/effective/validation.clj
+++ b/src/effective/validation.clj
@@ -23,7 +23,7 @@
 (def ^:private to-conjoin-valid?
   (every-pred map?
               :to-conjoin
-              :with))
+              (comp vector? :with)))
 
 (def ^:private assertion-config-valid?
   (every-pred map?

--- a/test/effective/assertion_test.clj
+++ b/test/effective/assertion_test.clj
@@ -4,7 +4,7 @@
 
 (deftest from
   (let [assertions (make {:from 4} 3)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= 4 expected))
@@ -12,7 +12,7 @@
 
 (deftest from-lt
   (let [assertions (make {:from-lt 31} 9)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 31 expected))
@@ -20,7 +20,7 @@
 
 (deftest from-less-than
   (let [assertions (make {:from-less-than 28} 18)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 28 expected))
@@ -28,7 +28,7 @@
 
 (deftest from-lte
   (let [assertions (make {:from-lte 68} 7)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 68 expected))
@@ -36,7 +36,7 @@
 
 (deftest from-less-than-or-equal
   (let [assertions (make {:from-less-than-or-equal -52} 13)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= -52 expected))
@@ -44,7 +44,7 @@
 
 (deftest from-gt
   (let [assertions (make {:from-gt 44} 6)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 44 expected))
@@ -52,7 +52,7 @@
 
 (deftest from-greater-than
   (let [assertions (make {:from-greater-than -25} 15)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -25 expected))
@@ -60,7 +60,7 @@
 
 (deftest from-gte
   (let [assertions (make {:from-gte 14} 31)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 14 expected))
@@ -68,7 +68,7 @@
 
 (deftest from-greater-than-or-equal
   (let [assertions (make {:from-greater-than-or-equal 26} 4)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 26 expected))
@@ -76,7 +76,7 @@
 
 (deftest from-not
   (let [assertions (make {:from-not 228} 42)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 228 expected))
@@ -84,7 +84,7 @@
 
 (deftest to
   (let [assertions (make {:to -2} 2)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= -2 expected))
@@ -92,7 +92,7 @@
 
 (deftest to-lt
   (let [assertions (make {:to-lt 39} 2)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 39 expected))
@@ -100,7 +100,7 @@
 
 (deftest to-less-than
   (let [assertions (make {:to-less-than -17} 2)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= -17 expected))
@@ -108,7 +108,7 @@
 
 (deftest to-lte
   (let [assertions (make {:to-lte 74} 8)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 74 expected))
@@ -116,7 +116,7 @@
 
 (deftest to-less-than-or-equal
   (let [assertions (make {:to-less-than-or-equal -5} 0)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= -5 expected))
@@ -124,7 +124,7 @@
 
 (deftest to-gt
   (let [assertions (make {:to-gt 23} 3)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 23 expected))
@@ -132,7 +132,7 @@
 
 (deftest to-greater-than
   (let [assertions (make {:to-greater-than -1} 9)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -1 expected))
@@ -140,7 +140,7 @@
 
 (deftest to-gte
   (let [assertions (make {:to-gte 91} 4)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 91 expected))
@@ -148,7 +148,7 @@
 
 (deftest to-greater-than-or-equal
   (let [assertions (make {:to-greater-than-or-equal 103} 10)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 103 expected))
@@ -156,7 +156,7 @@
 
 (deftest to-not
   (let [assertions (make {:to-not 121} 22)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 121 expected))
@@ -164,7 +164,7 @@
 
 (deftest by
   (let [assertions (make {:by 10} 0)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= 10 expected))
@@ -174,7 +174,7 @@
 
 (deftest by-lt
   (let [assertions (make {:by-lt 39} 16)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 39 expected))
@@ -184,7 +184,7 @@
 
 (deftest by-less-than
   (let [assertions (make {:by-less-than -8} 24)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= -8 expected))
@@ -194,7 +194,7 @@
 
 (deftest by-lte
   (let [assertions (make {:by-lte 43} 34)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 43 expected))
@@ -204,7 +204,7 @@
 
 (deftest by-less-than-or-equal
   (let [assertions (make {:by-less-than-or-equal 66} 26)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 66 expected))
@@ -214,7 +214,7 @@
 
 (deftest by-gt
   (let [assertions (make {:by-gt 40} 38)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 40 expected))
@@ -224,7 +224,7 @@
 
 (deftest by-greater-than
   (let [assertions (make {:by-greater-than -10} 29)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -10 expected))
@@ -234,7 +234,7 @@
 
 (deftest by-gte
   (let [assertions (make {:by-gte 51} 33)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 51 expected))
@@ -244,7 +244,7 @@
 
 (deftest by-greater-than-or-equal
   (let [assertions (make {:by-greater-than-or-equal 52} 46)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 52 expected))
@@ -254,7 +254,7 @@
 
 (deftest by-not
   (let [assertions (make {:by-not 71} 49)
-        [[operator expected actual]] (:predicates (first assertions))]
+        [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 71 expected))
@@ -266,6 +266,6 @@
   (let [assertions (make {:from 1 :to 21 :by 20} 7)
         [from-assertion to-assertion by-assertion] assertions]
     (is (= 3 (count assertions)))
-    (is (= 1 (-> from-assertion :predicates first (nth 1 nil))))
-    (is (= 21 (-> to-assertion :predicates first (nth 1 nil))))
-    (is (= 20 (-> by-assertion :predicates first (nth 1 nil))))))
+    (is (= 1 (-> from-assertion :predicate (nth 1 nil))))
+    (is (= 21 (-> to-assertion :predicate (nth 1 nil))))
+    (is (= 20 (-> by-assertion :predicate (nth 1 nil))))))

--- a/test/effective/assertion_test.clj
+++ b/test/effective/assertion_test.clj
@@ -3,7 +3,7 @@
             [effective.assertion :refer [make]]))
 
 (deftest from
-  (let [assertions (make {:from 4} 3)
+  (let [assertions (make {:to-change nil :from 4} 3)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
@@ -11,7 +11,7 @@
     (is (= 'before-3 actual))))
 
 (deftest from-lt
-  (let [assertions (make {:from-lt 31} 9)
+  (let [assertions (make {:to-change nil :from-lt 31} 9)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -19,7 +19,7 @@
     (is (= 'before-9 actual))))
 
 (deftest from-less-than
-  (let [assertions (make {:from-less-than 28} 18)
+  (let [assertions (make {:to-change nil :from-less-than 28} 18)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -27,7 +27,7 @@
     (is (= 'before-18 actual))))
 
 (deftest from-lte
-  (let [assertions (make {:from-lte 68} 7)
+  (let [assertions (make {:to-change nil :from-lte 68} 7)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -35,7 +35,7 @@
     (is (= 'before-7 actual))))
 
 (deftest from-less-than-or-equal
-  (let [assertions (make {:from-less-than-or-equal -52} 13)
+  (let [assertions (make {:to-change nil :from-less-than-or-equal -52} 13)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -43,7 +43,7 @@
     (is (= 'before-13 actual))))
 
 (deftest from-gt
-  (let [assertions (make {:from-gt 44} 6)
+  (let [assertions (make {:to-change nil :from-gt 44} 6)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -51,7 +51,7 @@
     (is (= 'before-6 actual))))
 
 (deftest from-greater-than
-  (let [assertions (make {:from-greater-than -25} 15)
+  (let [assertions (make {:to-change nil :from-greater-than -25} 15)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -59,7 +59,7 @@
     (is (= 'before-15 actual))))
 
 (deftest from-gte
-  (let [assertions (make {:from-gte 14} 31)
+  (let [assertions (make {:to-change nil :from-gte 14} 31)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -67,7 +67,7 @@
     (is (= 'before-31 actual))))
 
 (deftest from-greater-than-or-equal
-  (let [assertions (make {:from-greater-than-or-equal 26} 4)
+  (let [assertions (make {:to-change nil :from-greater-than-or-equal 26} 4)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -75,7 +75,7 @@
     (is (= 'before-4 actual))))
 
 (deftest from-not
-  (let [assertions (make {:from-not 228} 42)
+  (let [assertions (make {:to-change nil :from-not 228} 42)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
@@ -83,7 +83,7 @@
     (is (= 'before-42 actual))))
 
 (deftest to
-  (let [assertions (make {:to -2} 2)
+  (let [assertions (make {:to-change nil :to -2} 2)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
@@ -91,7 +91,7 @@
     (is (= 'after-2 actual))))
 
 (deftest to-lt
-  (let [assertions (make {:to-lt 39} 2)
+  (let [assertions (make {:to-change nil :to-lt 39} 2)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -99,7 +99,7 @@
     (is (= 'after-2 actual))))
 
 (deftest to-less-than
-  (let [assertions (make {:to-less-than -17} 2)
+  (let [assertions (make {:to-change nil :to-less-than -17} 2)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -107,7 +107,7 @@
     (is (= 'after-2 actual))))
 
 (deftest to-lte
-  (let [assertions (make {:to-lte 74} 8)
+  (let [assertions (make {:to-change nil :to-lte 74} 8)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -115,7 +115,7 @@
     (is (= 'after-8 actual))))
 
 (deftest to-less-than-or-equal
-  (let [assertions (make {:to-less-than-or-equal -5} 0)
+  (let [assertions (make {:to-change nil :to-less-than-or-equal -5} 0)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -123,7 +123,7 @@
     (is (= 'after-0 actual))))
 
 (deftest to-gt
-  (let [assertions (make {:to-gt 23} 3)
+  (let [assertions (make {:to-change nil :to-gt 23} 3)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -131,7 +131,7 @@
     (is (= 'after-3 actual))))
 
 (deftest to-greater-than
-  (let [assertions (make {:to-greater-than -1} 9)
+  (let [assertions (make {:to-change nil :to-greater-than -1} 9)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -139,7 +139,7 @@
     (is (= 'after-9 actual))))
 
 (deftest to-gte
-  (let [assertions (make {:to-gte 91} 4)
+  (let [assertions (make {:to-change nil :to-gte 91} 4)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -147,7 +147,7 @@
     (is (= 'after-4 actual))))
 
 (deftest to-greater-than-or-equal
-  (let [assertions (make {:to-greater-than-or-equal 103} 10)
+  (let [assertions (make {:to-change nil :to-greater-than-or-equal 103} 10)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -155,7 +155,7 @@
     (is (= 'after-10 actual))))
 
 (deftest to-not
-  (let [assertions (make {:to-not 121} 22)
+  (let [assertions (make {:to-change nil :to-not 121} 22)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
@@ -163,7 +163,7 @@
     (is (= 'after-22 actual))))
 
 (deftest by
-  (let [assertions (make {:by 10} 0)
+  (let [assertions (make {:to-change nil :by 10} 0)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
@@ -173,7 +173,7 @@
     (is (= 'before-0 (nth actual 2 nil)))))
 
 (deftest by-lt
-  (let [assertions (make {:by-lt 39} 16)
+  (let [assertions (make {:to-change nil :by-lt 39} 16)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -183,7 +183,7 @@
     (is (= 'before-16 (nth actual 2 nil)))))
 
 (deftest by-less-than
-  (let [assertions (make {:by-less-than -8} 24)
+  (let [assertions (make {:to-change nil :by-less-than -8} 24)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
@@ -193,7 +193,7 @@
     (is (= 'before-24 (nth actual 2 nil)))))
 
 (deftest by-lte
-  (let [assertions (make {:by-lte 43} 34)
+  (let [assertions (make {:to-change nil :by-lte 43} 34)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -203,7 +203,7 @@
     (is (= 'before-34 (nth actual 2 nil)))))
 
 (deftest by-less-than-or-equal
-  (let [assertions (make {:by-less-than-or-equal 66} 26)
+  (let [assertions (make {:to-change nil :by-less-than-or-equal 66} 26)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
@@ -213,7 +213,7 @@
     (is (= 'before-26 (nth actual 2 nil)))))
 
 (deftest by-gt
-  (let [assertions (make {:by-gt 40} 38)
+  (let [assertions (make {:to-change nil :by-gt 40} 38)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -223,7 +223,7 @@
     (is (= 'before-38 (nth actual 2 nil)))))
 
 (deftest by-greater-than
-  (let [assertions (make {:by-greater-than -10} 29)
+  (let [assertions (make {:to-change nil :by-greater-than -10} 29)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
@@ -233,7 +233,7 @@
     (is (= 'before-29 (nth actual 2 nil)))))
 
 (deftest by-gte
-  (let [assertions (make {:by-gte 51} 33)
+  (let [assertions (make {:to-change nil :by-gte 51} 33)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -243,7 +243,7 @@
     (is (= 'before-33 (nth actual 2 nil)))))
 
 (deftest by-greater-than-or-equal
-  (let [assertions (make {:by-greater-than-or-equal 52} 46)
+  (let [assertions (make {:to-change nil :by-greater-than-or-equal 52} 46)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
@@ -253,7 +253,7 @@
     (is (= 'before-46 (nth actual 2 nil)))))
 
 (deftest by-not
-  (let [assertions (make {:by-not 71} 49)
+  (let [assertions (make {:to-change nil :by-not 71} 49)
         [operator expected actual] (:predicate (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
@@ -263,7 +263,7 @@
     (is (= 'before-49 (nth actual 2 nil)))))
 
 (deftest multiple
-  (let [assertions (make {:from 1 :to 21 :by 20} 7)
+  (let [assertions (make {:to-change nil :from 1 :to 21 :by 20} 7)
         [from-assertion to-assertion by-assertion] assertions]
     (is (= 3 (count assertions)))
     (is (= 1 (-> from-assertion :predicate (nth 1 nil))))

--- a/test/effective/assertion_test.clj
+++ b/test/effective/assertion_test.clj
@@ -4,7 +4,7 @@
 
 (deftest from
   (let [assertions (make {:from 4} 3)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= 4 expected))
@@ -12,7 +12,7 @@
 
 (deftest from-lt
   (let [assertions (make {:from-lt 31} 9)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 31 expected))
@@ -20,7 +20,7 @@
 
 (deftest from-less-than
   (let [assertions (make {:from-less-than 28} 18)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 28 expected))
@@ -28,7 +28,7 @@
 
 (deftest from-lte
   (let [assertions (make {:from-lte 68} 7)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 68 expected))
@@ -36,7 +36,7 @@
 
 (deftest from-less-than-or-equal
   (let [assertions (make {:from-less-than-or-equal -52} 13)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= -52 expected))
@@ -44,7 +44,7 @@
 
 (deftest from-gt
   (let [assertions (make {:from-gt 44} 6)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 44 expected))
@@ -52,7 +52,7 @@
 
 (deftest from-greater-than
   (let [assertions (make {:from-greater-than -25} 15)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -25 expected))
@@ -60,7 +60,7 @@
 
 (deftest from-gte
   (let [assertions (make {:from-gte 14} 31)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 14 expected))
@@ -68,7 +68,7 @@
 
 (deftest from-greater-than-or-equal
   (let [assertions (make {:from-greater-than-or-equal 26} 4)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 26 expected))
@@ -76,7 +76,7 @@
 
 (deftest from-not
   (let [assertions (make {:from-not 228} 42)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 228 expected))
@@ -84,7 +84,7 @@
 
 (deftest to
   (let [assertions (make {:to -2} 2)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= -2 expected))
@@ -92,7 +92,7 @@
 
 (deftest to-lt
   (let [assertions (make {:to-lt 39} 2)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 39 expected))
@@ -100,7 +100,7 @@
 
 (deftest to-less-than
   (let [assertions (make {:to-less-than -17} 2)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= -17 expected))
@@ -108,7 +108,7 @@
 
 (deftest to-lte
   (let [assertions (make {:to-lte 74} 8)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 74 expected))
@@ -116,7 +116,7 @@
 
 (deftest to-less-than-or-equal
   (let [assertions (make {:to-less-than-or-equal -5} 0)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= -5 expected))
@@ -124,7 +124,7 @@
 
 (deftest to-gt
   (let [assertions (make {:to-gt 23} 3)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 23 expected))
@@ -132,7 +132,7 @@
 
 (deftest to-greater-than
   (let [assertions (make {:to-greater-than -1} 9)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -1 expected))
@@ -140,7 +140,7 @@
 
 (deftest to-gte
   (let [assertions (make {:to-gte 91} 4)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 91 expected))
@@ -148,7 +148,7 @@
 
 (deftest to-greater-than-or-equal
   (let [assertions (make {:to-greater-than-or-equal 103} 10)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 103 expected))
@@ -156,7 +156,7 @@
 
 (deftest to-not
   (let [assertions (make {:to-not 121} 22)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 121 expected))
@@ -164,7 +164,7 @@
 
 (deftest by
   (let [assertions (make {:by 10} 0)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'=) operator))
     (is (= 10 expected))
@@ -174,7 +174,7 @@
 
 (deftest by-lt
   (let [assertions (make {:by-lt 39} 16)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= 39 expected))
@@ -184,7 +184,7 @@
 
 (deftest by-less-than
   (let [assertions (make {:by-less-than -8} 24)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>) operator))
     (is (= -8 expected))
@@ -194,7 +194,7 @@
 
 (deftest by-lte
   (let [assertions (make {:by-lte 43} 34)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 43 expected))
@@ -204,7 +204,7 @@
 
 (deftest by-less-than-or-equal
   (let [assertions (make {:by-less-than-or-equal 66} 26)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'>=) operator))
     (is (= 66 expected))
@@ -214,7 +214,7 @@
 
 (deftest by-gt
   (let [assertions (make {:by-gt 40} 38)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= 40 expected))
@@ -224,7 +224,7 @@
 
 (deftest by-greater-than
   (let [assertions (make {:by-greater-than -10} 29)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<) operator))
     (is (= -10 expected))
@@ -234,7 +234,7 @@
 
 (deftest by-gte
   (let [assertions (make {:by-gte 51} 33)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 51 expected))
@@ -244,7 +244,7 @@
 
 (deftest by-greater-than-or-equal
   (let [assertions (make {:by-greater-than-or-equal 52} 46)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'<=) operator))
     (is (= 52 expected))
@@ -254,7 +254,7 @@
 
 (deftest by-not
   (let [assertions (make {:by-not 71} 49)
-        [operator expected actual] (:predicate (first assertions))]
+        [[operator expected actual]] (:predicates (first assertions))]
     (is (= 1 (count assertions)))
     (is (= (symbol #'not=) operator))
     (is (= 71 expected))
@@ -266,6 +266,6 @@
   (let [assertions (make {:from 1 :to 21 :by 20} 7)
         [from-assertion to-assertion by-assertion] assertions]
     (is (= 3 (count assertions)))
-    (is (= 1 (-> from-assertion :predicate (nth 1 nil))))
-    (is (= 21 (-> to-assertion :predicate (nth 1 nil))))
-    (is (= 20 (-> by-assertion :predicate (nth 1 nil))))))
+    (is (= 1 (-> from-assertion :predicates first (nth 1 nil))))
+    (is (= 21 (-> to-assertion :predicates first (nth 1 nil))))
+    (is (= 20 (-> by-assertion :predicates first (nth 1 nil))))))

--- a/test/effective/config_test.clj
+++ b/test/effective/config_test.clj
@@ -6,5 +6,5 @@
   (is (= [:w :x :y :z]
          (config/observables [{:to-change :w :from odd? :to even?}
                               {:to-conjoin :x :with 12}
-                              {:to-change :y :by 1}
+                              {:to-pop :y}
                               {:to-not-change :z}]))))

--- a/test/effective/config_test.clj
+++ b/test/effective/config_test.clj
@@ -1,0 +1,10 @@
+(ns effective.config-test
+  (:require [clojure.test :refer [deftest is]]
+            [effective.config :as config]))
+
+(deftest observables
+  (is (= [:w :x :y :z]
+         (config/observables [{:to-change :w :from odd? :to even?}
+                              {:to-conjoin :x :with 12}
+                              {:to-change :y :by 1}
+                              {:to-not-change :z}]))))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -186,38 +186,42 @@
             [{:to-change @x :from odd? :to even?}
              {:to-change @x :from 10}])))
 
-(defn- contains-hash? [h1]
-  (fn [h2]
-    (cljset/subset? (set h1) (set h2))))
-
 (deftest conjoin-vector-with-value
   (let [x (atom [:a :b])]
-    (expect (swap! x conj :c)
+    (expect (reset! x [:a :b :c])
             [{:to-conjoin @x :with [:c]}])))
 
 (deftest conjoin-vector-with-multiple-values
   (let [x (atom [:a :b])]
-    (expect (swap! x conj :c :d)
+    (expect (reset! x [:a :b :c :d])
             [{:to-conjoin @x :with [:c :d]}])))
 
 (deftest conjoin-list-with-value
   (let [x (atom '(:b :c))]
-    (expect (swap! x conj :a) :all
+    (expect (reset! x '(:a :b :c))
             [{:to-conjoin @x :with [:a]}])))
 
 (deftest conjoin-list-with-multiple-values
   (let [x (atom '(:c :d))]
-    (expect (swap! x conj :b :a) :all
+    (expect (reset! x '(:a :b :c :d))
             [{:to-conjoin @x :with [:b :a]}])))
+
+(defn- contains-hash? [h1]
+  (fn [h2]
+    (cljset/subset? (set h1) (set h2))))
 
 (deftest conjoin-vector-with-function
   (let [x (atom [{:a 1 :w 0 :z -9}
                  {:b 2 :w 0 :z -8}])]
-    (expect (swap! x conj {:c 3 :w 0 :z -7})
+    (expect (reset! x [{:a 1 :w 0 :z -9}
+                       {:b 2 :w 0 :z -8}
+                       {:c 3 :w 0 :z -7}])
             [{:to-conjoin @x :with [(contains-hash? {:c 3 :z -7})]}])))
 
 (deftest conjoin-list-with-function
-  (let [x (atom '({:a 1 :w 0 :z -9}
-                  {:b 2 :w 0 :z -8}))]
-    (expect (swap! x conj {:c 3 :w 0 :z -7})
-            [{:to-conjoin @x :with [(contains-hash? {:c 3 :z -7})]}])))
+  (let [x (atom '({:b 2 :w 0 :z -8}
+                  {:c 3 :w 0 :z -7}))]
+    (expect (reset! x '({:a 1 :w 0 :z -9}
+                        {:b 2 :w 0 :z -8}
+                        {:c 3 :w 0 :z -7}))
+            [{:to-conjoin @x :with [(contains-hash? {:a 1 :z -9})]}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -235,3 +235,13 @@
                         {:b 2 :w 0 :z -8}
                         {:c 3 :w 0 :z -7}))
             [{:to-conjoin @x :with [(contains-hash? {:a 1 :z -9})]}])))
+
+(deftest pop-vector-single
+  (let [x (atom [:a :b :c])]
+    (expect (reset! x [:a :b])
+            [{:to-pop @x}])))
+
+(deftest pop-list-single
+  (let [x (atom '(:a :b :c))]
+    (expect (reset! x '(:b :c))
+            [{:to-pop @x}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -185,7 +185,13 @@
             [{:to-change @x :from odd? :to even?}
              {:to-change @x :from 10}])))
 
-(deftest conjoin
+(deftest conjoin-with
   (let [x (atom [:a :b])]
     (expect (swap! x conj :c)
             [{:to-conjoin @x :with :c}])))
+
+(deftest conjoin-with-hash-containing
+  (let [x (atom [{:a 1 :w 0 :z -9}
+                 {:b 2 :w 0 :z -8}])]
+    (expect (swap! x conj {:c 3 :w 0 :z -7})
+            [{:to-conjoin @x :with-hash-containing {:c 3 :z -7}}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -241,7 +241,17 @@
     (expect (reset! x [:a :b])
             [{:to-pop @x}])))
 
+(deftest pop-vector-multiple
+  (let [x (atom [:a :b :c :d :e])]
+    (expect (reset! x [:a :b])
+            [{:to-pop @x :times 3}])))
+
 (deftest pop-list-single
   (let [x (atom '(:a :b :c))]
     (expect (reset! x '(:b :c))
             [{:to-pop @x}])))
+
+(deftest pop-list-multiple
+  (let [x (atom '(:a :b :c :d :e))]
+    (expect (reset! x '(:d :e))
+            [{:to-pop @x :times 3}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -196,6 +196,11 @@
     (expect (reset! x [:a :b :c :d])
             [{:to-conjoin @x :with [:c :d]}])))
 
+(deftest conjoin-vector-with-value-and-function
+  (let [x (atom [-2 -1])]
+    (expect (reset! x [-2 -1 0 1 2])
+            [{:to-conjoin @x :with [zero? 1 even?]}])))
+
 (deftest conjoin-list-with-value
   (let [x (atom '(:b :c))]
     (expect (reset! x '(:a :b :c))
@@ -205,6 +210,11 @@
   (let [x (atom '(:c :d))]
     (expect (reset! x '(:a :b :c :d))
             [{:to-conjoin @x :with [:b :a]}])))
+
+(deftest conjoin-list-with-value-and-function
+  (let [x (atom '(1 2))]
+    (expect (reset! x '(-2 -1 0 1 2))
+            [{:to-conjoin @x :with [zero? -1 (every-pred neg? even?)]}])))
 
 (defn- contains-hash? [h1]
   (fn [h2]

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -185,13 +185,24 @@
             [{:to-change @x :from odd? :to even?}
              {:to-change @x :from 10}])))
 
-(deftest conjoin-with
+(deftest conjoin-vector-with
   (let [x (atom [:a :b])]
     (expect (swap! x conj :c)
             [{:to-conjoin @x :with :c}])))
 
-(deftest conjoin-with-hash-containing
+(deftest conjoin-vector-with-hash-containing
   (let [x (atom [{:a 1 :w 0 :z -9}
                  {:b 2 :w 0 :z -8}])]
+    (expect (swap! x conj {:c 3 :w 0 :z -7})
+            [{:to-conjoin @x :with-hash-containing {:c 3 :z -7}}])))
+
+(deftest conjoin-list-with
+  (let [x (atom '(:b :c))]
+    (expect (swap! x conj :a) :all
+            [{:to-conjoin @x :with :a}])))
+
+(deftest conjoin-list-with-hash-containing
+  (let [x (atom '({:a 1 :w 0 :z -9}
+                  {:b 2 :w 0 :z -8}))]
     (expect (swap! x conj {:c 3 :w 0 :z -7})
             [{:to-conjoin @x :with-hash-containing {:c 3 :z -7}}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -193,21 +193,31 @@
 (deftest conjoin-vector-with-value
   (let [x (atom [:a :b])]
     (expect (swap! x conj :c)
-            [{:to-conjoin @x :with :c}])))
+            [{:to-conjoin @x :with [:c]}])))
+
+(deftest conjoin-vector-with-multiple-values
+  (let [x (atom [:a :b])]
+    (expect (swap! x conj :c :d)
+            [{:to-conjoin @x :with [:c :d]}])))
 
 (deftest conjoin-list-with-value
   (let [x (atom '(:b :c))]
     (expect (swap! x conj :a) :all
-            [{:to-conjoin @x :with :a}])))
+            [{:to-conjoin @x :with [:a]}])))
+
+(deftest conjoin-list-with-multiple-values
+  (let [x (atom '(:c :d))]
+    (expect (swap! x conj :b :a) :all
+            [{:to-conjoin @x :with [:b :a]}])))
 
 (deftest conjoin-vector-with-function
   (let [x (atom [{:a 1 :w 0 :z -9}
                  {:b 2 :w 0 :z -8}])]
     (expect (swap! x conj {:c 3 :w 0 :z -7})
-            [{:to-conjoin @x :with (contains-hash? {:c 3 :z -7})}])))
+            [{:to-conjoin @x :with [(contains-hash? {:c 3 :z -7})]}])))
 
 (deftest conjoin-list-with-function
   (let [x (atom '({:a 1 :w 0 :z -9}
                   {:b 2 :w 0 :z -8}))]
     (expect (swap! x conj {:c 3 :w 0 :z -7})
-            [{:to-conjoin @x :with (contains-hash? {:c 3 :z -7})}])))
+            [{:to-conjoin @x :with [(contains-hash? {:c 3 :z -7})]}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -1,5 +1,6 @@
 (ns effective.core-test
-  (:require [clojure.test :refer [deftest]]
+  (:require [clojure.set :as cljset]
+            [clojure.test :refer [deftest]]
             [effective.core :refer [expect]]))
 
 (deftest from-value
@@ -185,24 +186,28 @@
             [{:to-change @x :from odd? :to even?}
              {:to-change @x :from 10}])))
 
-(deftest conjoin-vector-with
+(defn- contains-hash? [h1]
+  (fn [h2]
+    (cljset/subset? (set h1) (set h2))))
+
+(deftest conjoin-vector-with-value
   (let [x (atom [:a :b])]
     (expect (swap! x conj :c)
             [{:to-conjoin @x :with :c}])))
 
-(deftest conjoin-vector-with-hash-containing
-  (let [x (atom [{:a 1 :w 0 :z -9}
-                 {:b 2 :w 0 :z -8}])]
-    (expect (swap! x conj {:c 3 :w 0 :z -7})
-            [{:to-conjoin @x :with-hash-containing {:c 3 :z -7}}])))
-
-(deftest conjoin-list-with
+(deftest conjoin-list-with-value
   (let [x (atom '(:b :c))]
     (expect (swap! x conj :a) :all
             [{:to-conjoin @x :with :a}])))
 
-(deftest conjoin-list-with-hash-containing
+(deftest conjoin-vector-with-function
+  (let [x (atom [{:a 1 :w 0 :z -9}
+                 {:b 2 :w 0 :z -8}])]
+    (expect (swap! x conj {:c 3 :w 0 :z -7})
+            [{:to-conjoin @x :with (contains-hash? {:c 3 :z -7})}])))
+
+(deftest conjoin-list-with-function
   (let [x (atom '({:a 1 :w 0 :z -9}
                   {:b 2 :w 0 :z -8}))]
     (expect (swap! x conj {:c 3 :w 0 :z -7})
-            [{:to-conjoin @x :with-hash-containing {:c 3 :z -7}}])))
+            [{:to-conjoin @x :with (contains-hash? {:c 3 :z -7})}])))

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -184,3 +184,8 @@
             :any
             [{:to-change @x :from odd? :to even?}
              {:to-change @x :from 10}])))
+
+(deftest conjoin
+  (let [x (atom [:a :b])]
+    (expect (swap! x conj :c)
+            [{:to-conjoin @x :with :c}])))

--- a/test/effective/validation_test.clj
+++ b/test/effective/validation_test.clj
@@ -13,4 +13,17 @@
     (is (thrown-with-msg? IllegalArgumentException
                           #"(?i)invalid"
                           (expect (swap! x inc) [{:to-change @x
-                                                  :to-not-change @x}])))))
+                                                  :to-not-change @x
+                                                  :to-conjoin @x}])))
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"(?i)invalid"
+                          (expect (swap! x inc) [{:to-change @x
+                                                  :to-not-change @x}])))
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"(?i)invalid"
+                          (expect (swap! x inc) [{:to-change @x
+                                                  :to-conjoin @x}])))
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"(?i)invalid"
+                          (expect (swap! x inc) [{:to-not-change @x
+                                                  :to-conjoin @x}])))))

--- a/test/effective/validation_test.clj
+++ b/test/effective/validation_test.clj
@@ -29,11 +29,17 @@
                           (expect (swap! x inc) [{:to-not-change @x
                                                   :to-conjoin @x}])))))
 
-(deftest to-conjoin-with-value
-  (is (config-valid? [{:to-conjoin :x :with 123}])))
+(deftest to-conjoin-with-scalar-value
+  (is (not (config-valid? [{:to-conjoin :x :with 123}]))))
 
-(deftest to-conjoin-with-function
-  (is (config-valid? [{:to-conjoin :x :with (constantly nil)}])))
+(deftest to-conjoin-with-scalar-function
+  (is (not (config-valid? [{:to-conjoin :x :with (constantly nil)}]))))
+
+(deftest to-conjoin-with-vector-value
+  (is (config-valid? [{:to-conjoin :x :with [123]}])))
+
+(deftest to-conjoin-with-vector-function
+  (is (config-valid? [{:to-conjoin :x :with [(constantly nil)]}])))
 
 (deftest to-conjoin-without-value
   (let [x (atom 0)]

--- a/test/effective/validation_test.clj
+++ b/test/effective/validation_test.clj
@@ -27,3 +27,9 @@
                           #"(?i)invalid"
                           (expect (swap! x inc) [{:to-not-change @x
                                                   :to-conjoin @x}])))))
+
+(deftest to-conjoin-without-value
+  (let [x (atom 0)]
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"(?i)invalid"
+                          (expect (swap! x inc) [{:to-conjoin @x}])))))

--- a/test/effective/validation_test.clj
+++ b/test/effective/validation_test.clj
@@ -29,14 +29,11 @@
                           (expect (swap! x inc) [{:to-not-change @x
                                                   :to-conjoin @x}])))))
 
-(deftest to-conjoin-with
+(deftest to-conjoin-with-value
   (is (config-valid? [{:to-conjoin :x :with 123}])))
 
-(deftest to-conjoin-with-hash-containing
-  (is (config-valid? [{:to-conjoin :x :with-hash-containing {:y 123}}])))
-
-(deftest to-conjoin-with-hash-containing-invalid-value
-  (is (not (config-valid? [{:to-conjoin :x :with-hash-containing 123}]))))
+(deftest to-conjoin-with-function
+  (is (config-valid? [{:to-conjoin :x :with (constantly nil)}])))
 
 (deftest to-conjoin-without-value
   (let [x (atom 0)]

--- a/test/effective/validation_test.clj
+++ b/test/effective/validation_test.clj
@@ -1,6 +1,7 @@
 (ns effective.validation-test
   (:require [clojure.test :refer [deftest is]]
-            [effective.core :refer [expect]]))
+            [effective.core :refer [expect]]
+            [effective.validation :refer [config-valid?]]))
 
 (deftest no-observable
   (let [x (atom 0)]
@@ -27,6 +28,15 @@
                           #"(?i)invalid"
                           (expect (swap! x inc) [{:to-not-change @x
                                                   :to-conjoin @x}])))))
+
+(deftest to-conjoin-with
+  (is (config-valid? [{:to-conjoin :x :with 123}])))
+
+(deftest to-conjoin-with-hash-containing
+  (is (config-valid? [{:to-conjoin :x :with-hash-containing {:y 123}}])))
+
+(deftest to-conjoin-with-hash-containing-invalid-value
+  (is (not (config-valid? [{:to-conjoin :x :with-hash-containing 123}]))))
 
 (deftest to-conjoin-without-value
   (let [x (atom 0)]


### PR DESCRIPTION
We often need to assert that a collection has grown. Furthermore, we additionally want to:
- assert properties of items added
- expect multiple additions
- expect shrinkage instead

Notes:
- introduces operations on observables:
  - `:to-conjoin`
  - `:to-pop`
- new operations work on vectors and lists
- introduces _discounted_ conformance of input to an implicit schema
- treats symbol-headed lists as functions (closes #5)
- flags may new be shared across operations
- improves validation of input
- tests validation