### PR TITLE
Feature: Value-agnostic mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.10.0] - 2025-02-08
+### Fixed
+- `:to-change` now stands alone ([#15](https://github.com/eureton/effective/issues/15))
+- problematic dependencies in binary ([#16](https://github.com/eureton/effective/issues/16))
+
 ## [0.9.0] - 2024-08-05
 ### Fixed
 - lopsided interpretation of arguments ([#11](https://github.com/eureton/effective/issues/11))
@@ -127,7 +132,8 @@ Renamed:
 - Initial commit.
 - asserts only, i.e. runs effect and monitors in a function.
 
-[Unreleased]: https://github.com/eureton/effective/compare/0.9.0...HEAD
+[Unreleased]: https://github.com/eureton/effective/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/eureton/effective/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/eureton/effective/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/eureton/effective/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/eureton/effective/compare/0.6.0...0.7.0

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,8 @@
   :license {:name "MIT"
             :url "https://github.com/eureton/effective/blob/master/LICENSE"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.flatland/useful "0.11.6"]
+                 [org.flatland/useful "0.11.6"
+                  :exclusions [org.clojure/tools.macro
+                               org.clojure/tools.reader]]
                  [metosin/malli "0.16.2"]]
   :repl-options {:init-ns effective.core})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.eureton/effective "0.9.0"
+(defproject com.eureton/effective "0.10.0"
   :description "RSpec-style expect-to-change assertions for Clojure."
   :url "https://github.com/eureton/effective"
   :license {:name "MIT"

--- a/src/effective/assertion.clj
+++ b/src/effective/assertion.clj
@@ -11,21 +11,21 @@
 (defn- inflate
   "Builds a function which turns a flag-value pair into a collection
    of data structures."
-  [index operation]
+  [index entry]
   (fn [[k v]]
     (map
       (fn [x]
         {:flag k
          :value v
-         :operation operation
+         :operation (config/operation entry)
          :predicate x
          :message (message k)})
-      (predicate/make operation k v index))))
+      (predicate/make entry k v index))))
 
 (defn make
   "Sequence of assertions which correspond to `entry`.
    Generates checkpoint references for position `index`."
   [entry index]
   (mapcat
-    (inflate index (config/operation entry))
+    (inflate index entry)
     entry))

--- a/src/effective/config/schema.clj
+++ b/src/effective/config/schema.clj
@@ -67,7 +67,6 @@
     [:by-gte OPT number?]
     [:by-within OPT value-range]
     [:by-not OPT :any]]
-   (minimum-one-constraint const/TO_CHANGE_FLAGS [:to-change])
    assertion])
 
 (def to-not-change

--- a/src/effective/predicate.clj
+++ b/src/effective/predicate.clj
@@ -1,9 +1,11 @@
 (ns effective.predicate
-  (:require [effective.checkpoint :as checkpoint]))
+  (:require [effective.checkpoint :as checkpoint]
+            [effective.config :as config]))
 
 (defmulti make
   "Quoted expressions representing the check specified by `flag`."
-  (fn [operation flag _ _] [operation flag]))
+  (fn [entry flag _ _]
+    [(config/operation entry) flag]))
 
 (defmethod make :default
   [_ _ _ _]
@@ -111,6 +113,13 @@
           (-> (- ~(checkpoint/after index) ~(checkpoint/before index))
               (- ~by-origin)
               (Math/abs)))]))
+
+(defmethod make [:to-change :to-change]
+  [entry _ _ index]
+  (let [solitary? (-> entry (dissoc :to-change) (empty?))]
+    (cond-> []
+      solitary? (conj `(not= ~(checkpoint/after index)
+                             ~(checkpoint/before index))))))
 
 (defmethod make [:to-not-change :to-not-change]
   [_ _ _ index]

--- a/test/effective/config/schema_test.clj
+++ b/test/effective/config/schema_test.clj
@@ -98,7 +98,7 @@
        :to-pop))
 
 (deftest to-change-no-flags
-  (is (not (m/validate schema/to-change {:to-change 'x}))))
+  (is (m/validate schema/to-change {:to-change 'x})))
 
 (deftest to-change-with-multiple-flags
   (is (m/validate schema/to-change {:to-change 'x

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -273,6 +273,11 @@
     (expect (swap! x inc)
             [{:to-change @x :by-within [0.1 :of 1.09]}])))
 
+(deftest change
+  (let [x (atom 2)]
+    (expect (swap! x inc)
+            [{:to-change @x}])))
+
 (deftest not-change
   (let [x (atom 2)]
     (expect (swap! x #(/ (* % %) 2))


### PR DESCRIPTION
Closes #15 and #16.

Notes:
- allows `:to-change` to stand alone
- generates an `(is (not= after before))` assertion
- excludes dependencies of `org.flatland/useful`:
  - `org.clojure/tools.macro`
  - `org.clojure/tools.reader`