### PR TITLE
Feature: Assert constancy of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.11.0] - 2025-02-10
+### Added
+- `:and-be` flag to `:to-not-change` ([#18](https://github.com/eureton/effective/issues/18))
+
 ## [0.10.0] - 2025-02-08
 ### Fixed
 - `:to-change` now stands alone ([#15](https://github.com/eureton/effective/issues/15))
@@ -132,7 +136,8 @@ Renamed:
 - Initial commit.
 - asserts only, i.e. runs effect and monitors in a function.
 
-[Unreleased]: https://github.com/eureton/effective/compare/0.10.0...HEAD
+[Unreleased]: https://github.com/eureton/effective/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/eureton/effective/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/eureton/effective/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/eureton/effective/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/eureton/effective/compare/0.7.0...0.8.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.eureton/effective "0.10.0"
+(defproject com.eureton/effective "0.11.0"
   :description "RSpec-style expect-to-change assertions for Clojure."
   :url "https://github.com/eureton/effective"
   :license {:name "MIT"

--- a/src/effective/config/schema.clj
+++ b/src/effective/config/schema.clj
@@ -72,7 +72,9 @@
 (def to-not-change
   "Describes `:to-not-change` entries."
   [:and
-   [:map [:to-not-change observable]]
+   [:map
+    [:to-not-change observable]
+    [:and-be OPT :any]]
    assertion])
 
 (def ^:private non-empty-vector

--- a/test/effective/assertion_test.clj
+++ b/test/effective/assertion_test.clj
@@ -191,6 +191,17 @@
     (is (= 'after-15 expected))
     (is (= 'before-15 actual))))
 
+(deftest and-be
+  (let [assertions (make {:to-not-change nil :and-be 24} 55)
+        predicate (:predicate (first assertions))
+        [operator expected actual-1 actual-2] predicate]
+    (is (= 1 (count assertions)))
+    (is (= 4 (count predicate)))
+    (is (= (symbol #'=) operator))
+    (is (= 24 expected))
+    (is (= 'after-55 actual-1))
+    (is (= 'before-55 actual-2))))
+
 (deftest multiple
   (let [assertions (make {:to-change nil :from 1 :to 21 :by 20} 7)
         [from-assertion to-assertion by-assertion] assertions]

--- a/test/effective/assertion_test.clj
+++ b/test/effective/assertion_test.clj
@@ -181,6 +181,16 @@
     (is (= 'after-49 (nth actual 1 nil)))
     (is (= 'before-49 (nth actual 2 nil)))))
 
+(deftest not-change
+  (let [assertions (make {:to-not-change nil} 15)
+        predicate (:predicate (first assertions))
+        [operator expected actual] predicate]
+    (is (= 1 (count assertions)))
+    (is (= 3 (count predicate)))
+    (is (= (symbol #'=) operator))
+    (is (= 'after-15 expected))
+    (is (= 'before-15 actual))))
+
 (deftest multiple
   (let [assertions (make {:to-change nil :from 1 :to 21 :by 20} 7)
         [from-assertion to-assertion by-assertion] assertions]

--- a/test/effective/core_test.clj
+++ b/test/effective/core_test.clj
@@ -283,6 +283,11 @@
     (expect (swap! x #(/ (* % %) 2))
             [{:to-not-change @x}])))
 
+(deftest not-change-and-be
+  (let [x (atom 2)]
+    (expect (swap! x #(/ (* % %) 2))
+            [{:to-not-change @x :and-be 2}])))
+
 (deftest multiple
   (let [x (atom {:a 1 :b 10})]
     (expect (swap! x assoc :a 10 :b 100)


### PR DESCRIPTION
Closes #18. See `CHANGELOG.md` for details.

Notes:
- adds `:and-be` flag to `:to-not-change`
- `{:to-not-change x :and-be y}` generates an `(is (= y after before))` assertion